### PR TITLE
Sort media results by release date and fix Seerr seasons request

### DIFF
--- a/scripts/request.mjs
+++ b/scripts/request.mjs
@@ -28,6 +28,12 @@ if (type) {
   results = results.filter(r => r.mediaType === type);
 }
 
+results.sort((a, b) => {
+  const dateA = a.releaseDate || a.firstAirDate || "";
+  const dateB = b.releaseDate || b.firstAirDate || "";
+  return dateB.localeCompare(dateA);
+});
+
 const result = results[0];
 
 if (!result) {
@@ -42,7 +48,7 @@ const body = {
 
 if (seasons && body.mediaType === "tv") {
   if (seasons === "all") {
-    body.seasons = "all";
+    // omit seasons key — Seerr requests all seasons by default
   } else {
     const parsed = seasons.split(",").map(Number);
     if (parsed.some(n => !Number.isInteger(n) || n < 1)) {


### PR DESCRIPTION
## Summary
This PR improves the media request handling by sorting results by release date and fixing the Seerr API integration for TV season requests.

## Key Changes
- **Sort results by release date**: Added sorting logic that orders media results by `releaseDate` (for movies) or `firstAirDate` (for TV shows) in descending order, ensuring the most recent media is selected first
- **Fix Seerr TV seasons request**: Changed the behavior when requesting "all" seasons for TV shows to omit the `seasons` key entirely, as Seerr requests all seasons by default. This removes unnecessary redundant configuration.

## Implementation Details
- The sorting uses `localeCompare()` for date string comparison in descending order (newest first)
- Handles both movie and TV media types by checking for either `releaseDate` or `firstAirDate` fields
- Falls back to empty string if neither date field is present

https://claude.ai/code/session_013pdB7r7tE44YhfdaT4hhpT