### PR TITLE
Add TMDB ID lookup support to request script

### DIFF
--- a/openclaw-seerr-SKILL.md
+++ b/openclaw-seerr-SKILL.md
@@ -45,7 +45,9 @@ Use when the user says things like:
 
 - Always search first before requesting
 - Prefer exact title match
-- If multiple matches exist, prefer newest
+- If multiple distinct titles are returned (e.g. a franchise, remakes, or different shows with the same name), present the options to the user and ask which one they mean before requesting — include the title and year for each option
+- Once the user picks, use `--id` with the TMDB ID from the search result to request exactly that item
+- If results are clearly the same title (e.g. only quality variants), pick the best match without asking
 - Support TV season requests
 - Return request status after requesting
 
@@ -73,10 +75,39 @@ node {baseDir}/scripts/search.mjs "Severance" --type tv
 
 ---
 
+# Disambiguation
+
+When a search returns multiple distinct titles, show the user the options (title + year) and ask which one they mean. Then use `--id` to request the exact item by its TMDB ID.
+
+**Step 1 — Search:**
+```
+node {baseDir}/scripts/search.mjs "The Matrix" --type movie
+```
+
+**Step 2 — Present options to user:**
+> "Which Matrix did you mean?
+> 1. The Matrix (1999)
+> 2. The Matrix Reloaded (2003)
+> 3. The Matrix Revolutions (2003)
+> 4. The Matrix Resurrections (2021)"
+
+**Step 3 — Request by ID after user picks:**
+```
+node {baseDir}/scripts/request.mjs --id 603 --type movie
+```
+
+---
+
 # Request Movie
 
 ```
 node {baseDir}/scripts/request.mjs "Dune Part Two" --type movie
+```
+
+Request by TMDB ID (use after disambiguation):
+
+```
+node {baseDir}/scripts/request.mjs --id 603 --type movie
 ```
 
 ---
@@ -87,6 +118,12 @@ Request full series:
 
 ```
 node {baseDir}/scripts/request.mjs "Bluey" --type tv
+```
+
+Request by TMDB ID (use after disambiguation):
+
+```
+node {baseDir}/scripts/request.mjs --id 83053 --type tv
 ```
 
 Request specific season:

--- a/scripts/request.mjs
+++ b/scripts/request.mjs
@@ -2,7 +2,10 @@ import { seerr } from "./lib.mjs";
 
 const args = process.argv.slice(2);
 
-const query = args[0];
+const query = args[0] && !args[0].startsWith("--") ? args[0] : null;
+
+const idIdx = args.indexOf("--id");
+const id = idIdx >= 0 ? Number(args[idIdx + 1]) : null;
 
 const typeIdx = args.indexOf("--type");
 const type = typeIdx >= 0 ? args[typeIdx + 1] : null;
@@ -10,8 +13,19 @@ const type = typeIdx >= 0 ? args[typeIdx + 1] : null;
 const seasonIdx = args.indexOf("--seasons");
 const seasons = seasonIdx >= 0 ? args[seasonIdx + 1] : null;
 
-if (!query) {
+if (!query && !id) {
   console.error("Usage: request.mjs \"title\" [--type movie|tv] [--seasons all|1,2,3]");
+  console.error("       request.mjs --id <tmdb-id> --type movie|tv [--seasons all|1,2,3]");
+  process.exit(1);
+}
+
+if (id && !type) {
+  console.error("--type is required when using --id");
+  process.exit(1);
+}
+
+if (id && isNaN(id)) {
+  console.error("--id must be a number");
   process.exit(1);
 }
 
@@ -20,31 +34,37 @@ if (type && type !== "movie" && type !== "tv") {
   process.exit(1);
 }
 
-const search = await seerr(`/search?query=${encodeURIComponent(query)}`);
+let body;
 
-let results = search.results || [];
+if (id) {
+  body = { mediaId: id, mediaType: type };
+} else {
+  const search = await seerr(`/search?query=${encodeURIComponent(query)}`);
 
-if (type) {
-  results = results.filter(r => r.mediaType === type);
+  let results = search.results || [];
+
+  if (type) {
+    results = results.filter(r => r.mediaType === type);
+  }
+
+  results.sort((a, b) => {
+    const dateA = a.releaseDate || a.firstAirDate || "";
+    const dateB = b.releaseDate || b.firstAirDate || "";
+    return dateB.localeCompare(dateA);
+  });
+
+  const result = results[0];
+
+  if (!result) {
+    console.error("No results");
+    process.exit(1);
+  }
+
+  body = {
+    mediaId: result.id,
+    mediaType: type || result.mediaType
+  };
 }
-
-results.sort((a, b) => {
-  const dateA = a.releaseDate || a.firstAirDate || "";
-  const dateB = b.releaseDate || b.firstAirDate || "";
-  return dateB.localeCompare(dateA);
-});
-
-const result = results[0];
-
-if (!result) {
-  console.error("No results");
-  process.exit(1);
-}
-
-const body = {
-  mediaId: result.id,
-  mediaType: type || result.mediaType
-};
 
 if (seasons && body.mediaType === "tv") {
   if (seasons === "all") {


### PR DESCRIPTION
## Summary
Enhanced the request script to support requesting media by TMDB ID in addition to title search. This enables disambiguation workflows where users can search for a title, review multiple results, and then request a specific item by its ID.

## Key Changes
- **Added `--id` parameter** to `request.mjs` for direct TMDB ID-based requests
- **Made query optional** when `--id` is provided; query is now only required if ID is not specified
- **Added validation** for the `--id` parameter:
  - `--type` is now required when using `--id`
  - ID must be a valid number
- **Refactored request logic** to handle two paths:
  - Direct ID path: constructs request body directly from ID and type
  - Search path: performs title search and uses first result (existing behavior)
- **Updated documentation** with disambiguation workflow examples showing how to use `--id` after presenting search results to users

## Implementation Details
- The `--id` parameter accepts a TMDB ID and requires `--type` to be specified
- When `--id` is provided, the script skips the search step entirely
- Validation ensures proper usage with clear error messages for missing or invalid parameters
- The request body construction is now conditional based on whether ID or search is used

https://claude.ai/code/session_01YMBo6YZnH519uBgx5rcTE2