### PR TITLE
Add multi-user support via --user flag and SEERR_USERS config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ SEERR_API_KEY=your_api_key_here
 # Optional: map names to Seerr user IDs for multi-user support
 # Find user IDs in the Seerr admin panel under Users
 # SEERR_USERS=me:1,wife:2
+# Optional: map names to Seerr server IDs for multiple Radarr/Sonarr instances
+# Find server IDs in the Seerr admin panel under Settings → Radarr / Sonarr
+# SEERR_SERVERS=kids-movies:2,kids-tv:3

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 SEERR_URL=http://localhost:5055
 SEERR_API_KEY=your_api_key_here
+# Optional: map names to Seerr user IDs for multi-user support
+# Find user IDs in the Seerr admin panel under Users
+# SEERR_USERS=me:1,wife:2

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ metadata:
         "env": ["SEERR_URL", "SEERR_API_KEY"]
       },
       "primaryEnv": "SEERR_API_KEY",
-      "optionalEnv": ["SEERR_USERS"]
+      "optionalEnv": ["SEERR_USERS", "SEERR_SERVERS"]
     }
   }
 ---
@@ -54,6 +54,8 @@ Use when the user says things like:
 - If the request is on behalf of someone else (e.g. "my wife wants X", "add Y for [name]"), pass `--user <name>` — the name must match a key configured in `SEERR_USERS`
 - If `--user` is given but `SEERR_USERS` is not configured or the name is not found, the script will exit with an error — inform the user they need to configure `SEERR_USERS`
 - If the user asks you to request something for themselves and SEERR_USERS is configured with a name for them, use `--user` for their account too so the request is attributed correctly
+- If the user specifies a target library or server (e.g. "add to kids", "put it on the kids Radarr"), pass `--server <name>` — the name must match a key configured in `SEERR_SERVERS`
+- If `--server` is given but `SEERR_SERVERS` is not configured or the name is not found, the script will exit with an error — inform the user they need to configure `SEERR_SERVERS`
 
 ---
 
@@ -167,6 +169,40 @@ Check request:
 ```
 node {baseDir}/scripts/request-by-id.mjs 123
 ```
+
+---
+
+# Multi-Server Requests
+
+If `SEERR_SERVERS` is configured, you can route a request to a specific Radarr or Sonarr instance using `--server`:
+
+```
+node {baseDir}/scripts/request.mjs "Bluey" --type tv --server kids-tv
+```
+
+```
+node {baseDir}/scripts/request.mjs "Moana 2" --type movie --server kids-movies
+```
+
+`SEERR_SERVERS` must be set as a comma-separated list of `name:id` pairs where the ID is the Seerr server ID for that Radarr/Sonarr instance:
+
+```
+SEERR_SERVERS=kids-movies:2,kids-tv:3
+```
+
+To find a server's ID, visit the Seerr admin panel under Settings → Radarr or Settings → Sonarr — the ID is shown next to each configured server.
+
+`--server` and `--user` can be combined:
+
+```
+node {baseDir}/scripts/request.mjs "Moana 2" --type movie --server kids-movies --user wife
+```
+
+Detect the target server from conversational context:
+- "Request Bluey" → no `--server` (uses Seerr default)
+- "Add Bluey to kids" / "put it on kids Sonarr" → `--server kids-tv`
+- "Request Moana for the kids library" → `--server kids-movies`
+- "Add to the kids Radarr instead" → `--server kids-movies`
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,7 +8,8 @@ metadata:
         "bins": ["node"],
         "env": ["SEERR_URL", "SEERR_API_KEY"]
       },
-      "primaryEnv": "SEERR_API_KEY"
+      "primaryEnv": "SEERR_API_KEY",
+      "optionalEnv": ["SEERR_USERS"]
     }
   }
 ---
@@ -50,6 +51,9 @@ Use when the user says things like:
 - If results are clearly the same title (e.g. only quality variants), pick the best match without asking
 - Support TV season requests
 - Return request status after requesting
+- If the request is on behalf of someone else (e.g. "my wife wants X", "add Y for [name]"), pass `--user <name>` — the name must match a key configured in `SEERR_USERS`
+- If `--user` is given but `SEERR_USERS` is not configured or the name is not found, the script will exit with an error — inform the user they need to configure `SEERR_USERS`
+- If the user asks you to request something for themselves and SEERR_USERS is configured with a name for them, use `--user` for their account too so the request is attributed correctly
 
 ---
 
@@ -166,8 +170,37 @@ node {baseDir}/scripts/request-by-id.mjs 123
 
 ---
 
+# Multi-User Requests
+
+If `SEERR_USERS` is configured, you can attribute requests to a specific Seerr user using `--user`:
+
+```
+node {baseDir}/scripts/request.mjs "Bluey" --type tv --user wife
+```
+
+```
+node {baseDir}/scripts/request.mjs --id 83053 --type tv --user me
+```
+
+`SEERR_USERS` must be set as a comma-separated list of `name:id` pairs where the ID is the Seerr user ID:
+
+```
+SEERR_USERS=me:1,wife:2
+```
+
+To find a user's Seerr ID, visit the Seerr admin panel under Users.
+
+Detect who the request is for from conversational context:
+- "Request Bluey" → no `--user` (or use the current user's configured name)
+- "My wife wants Bluey" → `--user wife`
+- "Add Dune for me" → `--user me`
+- "Can you get Severance for [name]" → `--user [name]`
+
+---
+
 # Notes
 
 - This skill uses the Seerr API
 - Requires SEERR_URL and SEERR_API_KEY
 - Always search before requesting
+- `SEERR_USERS` is optional — omit it if you only have one user account

--- a/scripts/request.mjs
+++ b/scripts/request.mjs
@@ -13,10 +13,34 @@ const type = typeIdx >= 0 ? args[typeIdx + 1] : null;
 const seasonIdx = args.indexOf("--seasons");
 const seasons = seasonIdx >= 0 ? args[seasonIdx + 1] : null;
 
+const userIdx = args.indexOf("--user");
+const userName = userIdx >= 0 ? args[userIdx + 1] : null;
+
 if (!query && !id) {
-  console.error("Usage: request.mjs \"title\" [--type movie|tv] [--seasons all|1,2,3]");
-  console.error("       request.mjs --id <tmdb-id> --type movie|tv [--seasons all|1,2,3]");
+  console.error("Usage: request.mjs \"title\" [--type movie|tv] [--seasons all|1,2,3] [--user <name>]");
+  console.error("       request.mjs --id <tmdb-id> --type movie|tv [--seasons all|1,2,3] [--user <name>]");
   process.exit(1);
+}
+
+let userId = null;
+if (userName) {
+  const usersEnv = process.env.SEERR_USERS || "";
+  const userMap = Object.fromEntries(
+    usersEnv.split(",")
+      .filter(Boolean)
+      .map(entry => {
+        const colonIdx = entry.lastIndexOf(":");
+        const name = entry.slice(0, colonIdx).trim().toLowerCase();
+        const id = Number(entry.slice(colonIdx + 1).trim());
+        return [name, id];
+      })
+      .filter(([name, id]) => name && Number.isInteger(id) && id > 0)
+  );
+  userId = userMap[userName.toLowerCase()];
+  if (!userId) {
+    console.error(`Unknown user: "${userName}". Set SEERR_USERS=name:id,name:id to configure users.`);
+    process.exit(1);
+  }
 }
 
 if (id && !type) {
@@ -78,6 +102,8 @@ if (seasons && body.mediaType === "tv") {
     body.seasons = parsed;
   }
 }
+
+if (userId) body.userId = userId;
 
 const response = await seerr("/request", {
   method: "POST",

--- a/scripts/request.mjs
+++ b/scripts/request.mjs
@@ -16,17 +16,18 @@ const seasons = seasonIdx >= 0 ? args[seasonIdx + 1] : null;
 const userIdx = args.indexOf("--user");
 const userName = userIdx >= 0 ? args[userIdx + 1] : null;
 
+const serverIdx = args.indexOf("--server");
+const serverName = serverIdx >= 0 ? args[serverIdx + 1] : null;
+
 if (!query && !id) {
-  console.error("Usage: request.mjs \"title\" [--type movie|tv] [--seasons all|1,2,3] [--user <name>]");
-  console.error("       request.mjs --id <tmdb-id> --type movie|tv [--seasons all|1,2,3] [--user <name>]");
+  console.error("Usage: request.mjs \"title\" [--type movie|tv] [--seasons all|1,2,3] [--user <name>] [--server <name>]");
+  console.error("       request.mjs --id <tmdb-id> --type movie|tv [--seasons all|1,2,3] [--user <name>] [--server <name>]");
   process.exit(1);
 }
 
-let userId = null;
-if (userName) {
-  const usersEnv = process.env.SEERR_USERS || "";
-  const userMap = Object.fromEntries(
-    usersEnv.split(",")
+function parseNameIdMap(envValue) {
+  return Object.fromEntries(
+    (envValue || "").split(",")
       .filter(Boolean)
       .map(entry => {
         const colonIdx = entry.lastIndexOf(":");
@@ -36,9 +37,24 @@ if (userName) {
       })
       .filter(([name, id]) => name && Number.isInteger(id) && id > 0)
   );
+}
+
+let userId = null;
+if (userName) {
+  const userMap = parseNameIdMap(process.env.SEERR_USERS);
   userId = userMap[userName.toLowerCase()];
   if (!userId) {
     console.error(`Unknown user: "${userName}". Set SEERR_USERS=name:id,name:id to configure users.`);
+    process.exit(1);
+  }
+}
+
+let serverId = null;
+if (serverName) {
+  const serverMap = parseNameIdMap(process.env.SEERR_SERVERS);
+  serverId = serverMap[serverName.toLowerCase()];
+  if (!serverId) {
+    console.error(`Unknown server: "${serverName}". Set SEERR_SERVERS=name:id,name:id to configure servers.`);
     process.exit(1);
   }
 }
@@ -104,6 +120,7 @@ if (seasons && body.mediaType === "tv") {
 }
 
 if (userId) body.userId = userId;
+if (serverId) body.serverId = serverId;
 
 const response = await seerr("/request", {
   method: "POST",


### PR DESCRIPTION
Requests can now be attributed to specific Seerr users by passing
--user <name> to request.mjs. Names are resolved from the optional
SEERR_USERS=name:id,name:id environment variable.

SKILL.md updated with rules for detecting who the request is for
from conversational context (e.g. "my wife wants X").

https://claude.ai/code/session_0169K15ZPk2rebGjsLzTXPTN