### PR TITLE
Fix 500 error when requesting TV shows by always sending seasons explicitly

### DIFF
--- a/scripts/request.mjs
+++ b/scripts/request.mjs
@@ -106,9 +106,9 @@ if (id) {
   };
 }
 
-if (seasons && body.mediaType === "tv") {
-  if (seasons === "all") {
-    // omit seasons key — Seerr requests all seasons by default
+if (body.mediaType === "tv") {
+  if (!seasons || seasons === "all") {
+    body.seasons = "all";
   } else {
     const parsed = seasons.split(",").map(Number);
     if (parsed.some(n => !Number.isInteger(n) || n < 1)) {


### PR DESCRIPTION
The Seerr API (both Overseerr and Jellyseerr) requires `seasons` to be
explicitly set to either `'all'` or a number array for TV requests. When
`seasons` is omitted, the server-side ternary `seasons === 'all' ? ... :
(seasons as number[])` evaluates to `undefined`, which causes a TypeError
downstream and a 500 response.

Previously we omitted the `seasons` key under the assumption Seerr would
default to all seasons — it does not. Now we always send `seasons: 'all'`
for TV requests when no specific seasons are given.

https://claude.ai/code/session_017dEMfxba9Gr2DmSheUFzMp